### PR TITLE
Add model and PDF options with improved UI and token stats

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,22 +25,14 @@
   <main class="main">
     <div class="topbar">
       <div class="toolbar">
-        <label><input type="checkbox" id="webChk"> 🌐 Realtime web</label>
-        <label><input type="checkbox" id="memChk" checked> 🧠 Pamięć globalna</label>
-          <button id="imgBtn" title="Obraz z promptu">🖼️ Obraz</button>
-          <select id="voiceSel" title="Głos TTS"></select>
-          <button id="speakBtn" title="Czytaj na głos">▶️ Głos</button>
-          <select id="themeSel" title="Motyw">
-            <option value="theme-dark">Dark</option>
-            <option value="theme-light">Light</option>
-            <option value="theme-sepia">Sepia</option>
-            <option value="theme-contrast">High Contrast</option>
-          </select>
-          <button id="memPanelBtn">🔧 Pamięć</button>
-          <button id="filesBtn">📎 Pliki</button>
-          <div id="status" class="status">• gotowy</div>
-        </div>
+        <button id="imgBtn" title="Obraz z promptu">🖼️ Obraz</button>
+        <button id="filesBtn">📎 Pliki</button>
+        <button id="pdfBtn" title="Eksportuj do PDF">📄 PDF</button>
+        <button id="speakBtn" title="Czytaj na głos">▶️ Głos</button>
+        <button id="settingsBtn">⚙️ Ustawienia</button>
+        <div id="status" class="status">• gotowy</div>
       </div>
+    </div>
 
     <div class="card">
       <div id="chat"></div>
@@ -60,6 +52,31 @@
     <div class="note">Kliknij numer, aby przewinąć. ✏️ edycja etykiety.</div>
   </aside>
 </div>
+
+  <!-- Modal ustawień -->
+  <div id="settingsModal" class="modal hidden">
+    <div class="modalcard">
+      <div class="modalhead">
+        <h3>Ustawienia</h3>
+        <button id="settingsClose">✖</button>
+      </div>
+      <div class="modalbody">
+        <label><input type="checkbox" id="webChk"> 🌐 Realtime web</label>
+        <label><input type="checkbox" id="memChk" checked> 🧠 Pamięć globalna</label>
+        <div class="row"><span>Model:</span> <select id="modelSel"></select></div>
+        <div class="row"><span>Głos:</span> <select id="voiceSel"></select></div>
+        <div class="row"><span>Motyw:</span>
+          <select id="themeSel">
+            <option value="theme-dark">Dark</option>
+            <option value="theme-light">Light</option>
+            <option value="theme-sepia">Sepia</option>
+            <option value="theme-contrast">High Contrast</option>
+          </select>
+        </div>
+        <button id="memPanelBtn">🔧 Pamięć</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Modal pamięci -->
   <div id="memModal" class="modal hidden">

--- a/public/style.css
+++ b/public/style.css
@@ -33,6 +33,7 @@ button{background:var(--btn);color:var(--btn-fg);border:0;border-radius:10px;pad
 button:disabled{opacity:.6;cursor:not-allowed}
 .colbtns{display:flex;flex-direction:column;gap:8px}
 #micBtn.rec{background:#ef4444}
+#voiceSel{min-width:150px}
 
 img.chatimg{max-width:60%;border-radius:12px;border:1px solid var(--border);display:block}
 


### PR DESCRIPTION
## Summary
- Allow choosing among GPT-4o/GPT-5 models and expose `/api/models`
- Export threads to PDF and download via new toolbar button
- Simplify toolbar with settings modal, direct file uploads, wider voice selector, and token usage display

## Testing
- `python -m py_compile app.py`
- `pytest >/tmp/pytest.log && cat /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b360043818832d9e8cce50db5c9632