### PR TITLE
Serve public assets from root and hide modals by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -125,9 +125,10 @@ app = FastAPI(title="Prywatny czat z pamięcią")
 app.mount("/public", StaticFiles(directory=str(PUBLIC_DIR)), name="public")
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
-@app.get("/")
-def index():
-    return FileResponse(PUBLIC_DIR / "index.html")
+
+@app.get("/settings")
+def settings_page():
+    return FileResponse(PUBLIC_DIR / "settings.html")
 
 # -------------- DB + MIGRACJE ------------------
 def ensure_schema():
@@ -716,6 +717,9 @@ def health():
     import openai as _openai
     return {"ok": True, "openai_version": getattr(_openai, "__version__", "unknown"),
             "models": {"text": MODEL_TEXT, "stt": MODEL_STT, "tts": MODEL_TTS, "image": MODEL_IMAGE}}
+
+# Serve public directory at root so assets can be loaded relatively
+app.mount("/", StaticFiles(directory=str(PUBLIC_DIR), html=True), name="public_root")
 
 # -------------- AUTOSTART ----------------------
 if __name__ == "__main__":

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Prywatny czat</title>
-<link rel="stylesheet" href="/public/style.css">
+<link rel="stylesheet" href="style.css">
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlight.js@11.9.0/styles/github-dark.min.css">
@@ -53,60 +53,8 @@
   </aside>
 </div>
 
-  <!-- Modal ustawień -->
-  <div id="settingsModal" class="modal hidden">
-    <div class="modalcard">
-      <div class="modalhead">
-        <h3>Ustawienia</h3>
-        <button id="settingsClose">✖</button>
-      </div>
-      <div class="modalbody">
-        <label><input type="checkbox" id="webChk"> 🌐 Realtime web</label>
-        <label><input type="checkbox" id="memChk" checked> 🧠 Pamięć globalna</label>
-        <div class="row"><span>Model:</span> <select id="modelSel"></select></div>
-        <div class="row"><span>Głos:</span> <select id="voiceSel"></select></div>
-        <div class="row"><span>Motyw:</span>
-          <select id="themeSel">
-            <option value="theme-dark">Dark</option>
-            <option value="theme-light">Light</option>
-            <option value="theme-sepia">Sepia</option>
-            <option value="theme-contrast">High Contrast</option>
-          </select>
-        </div>
-        <button id="memPanelBtn">🔧 Pamięć</button>
-      </div>
-    </div>
-  </div>
-
-  <!-- Modal pamięci -->
-  <div id="memModal" class="modal hidden">
-    <div class="modalcard">
-      <div class="modalhead">
-        <h3>Pamięć globalna</h3>
-        <button id="memClose">✖</button>
-      </div>
-      <div class="modalbody">
-        <div class="row">
-          <input id="memKey" placeholder="klucz (opcjonalnie)">
-          <select id="memScope">
-            <option value="style">style</option>
-            <option value="voice">voice</option>
-            <option value="facts">facts</option>
-            <option value="other" selected>other</option>
-          </select>
-        </div>
-        <textarea id="memValue" rows="3" placeholder="treść do zapamiętania"></textarea>
-        <div class="row">
-          <button id="memAdd">➕ Dodaj</button>
-          <button id="memRefresh">🔄 Odśwież</button>
-        </div>
-        <div id="memList" class="memlist"></div>
-      </div>
-    </div>
-  </div>
-
   <!-- Modal plików -->
-  <div id="filesModal" class="modal hidden">
+  <div id="filesModal" class="modal" hidden>
     <div class="modalcard">
       <div class="modalhead">
         <h3>Pliki</h3>
@@ -123,7 +71,7 @@
 
   <input id="fileInp" type="file" multiple style="display:none">
 
-<script src="/public/script.js"></script>
+<script src="script.js"></script>
 </body>
 </html>
 

--- a/public/settings.css
+++ b/public/settings.css
@@ -1,0 +1,5 @@
+@import "./style.css";
+
+.setwrap{max-width:600px;margin:20px auto;padding:12px;}
+.setwrap .row{display:flex;gap:8px;align-items:center;margin:8px 0;}
+.setwrap label{display:block;margin:8px 0;}

--- a/public/settings.html
+++ b/public/settings.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="pl">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Ustawienia</title>
+<link rel="stylesheet" href="settings.css">
+</head>
+<body class="theme-dark">
+<div class="setwrap">
+  <div class="card">
+    <h3>Ustawienia</h3>
+    <label><input type="checkbox" id="webChk"> 🌐 Realtime web</label>
+    <label><input type="checkbox" id="memChk"> 🧠 Pamięć globalna</label>
+    <div class="row"><span>Model:</span> <select id="modelSel"></select></div>
+    <div class="row"><span>Głos:</span> <select id="voiceSel"></select></div>
+    <div class="row"><span>Motyw:</span>
+      <select id="themeSel">
+        <option value="theme-dark">Dark</option>
+        <option value="theme-light">Light</option>
+        <option value="theme-sepia">Sepia</option>
+        <option value="theme-contrast">High Contrast</option>
+      </select>
+    </div>
+    <div class="row">
+      <button id="memPanelBtn">🔧 Pamięć</button>
+      <button id="backBtn">⬅ Powrót</button>
+    </div>
+  </div>
+
+  <div id="memModal" class="modal" hidden>
+    <div class="modalcard">
+      <div class="modalhead">
+        <h3>Pamięć globalna</h3>
+        <button id="memClose">✖</button>
+      </div>
+      <div class="modalbody">
+        <div class="row">
+          <input id="memKey" placeholder="klucz (opcjonalnie)">
+          <select id="memScope">
+            <option value="style">style</option>
+            <option value="voice">voice</option>
+            <option value="facts">facts</option>
+            <option value="other" selected>other</option>
+          </select>
+        </div>
+        <textarea id="memValue" rows="3" placeholder="treść do zapamiętania"></textarea>
+        <div class="row">
+          <button id="memAdd">➕ Dodaj</button>
+          <button id="memRefresh">🔄 Odśwież</button>
+        </div>
+        <div id="memList" class="memlist"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="settings.js"></script>
+</body>
+</html>

--- a/public/settings.js
+++ b/public/settings.js
@@ -1,0 +1,132 @@
+const webChk = document.getElementById('webChk');
+const memChk = document.getElementById('memChk');
+const modelSel = document.getElementById('modelSel');
+const voiceSel = document.getElementById('voiceSel');
+const themeSel = document.getElementById('themeSel');
+const memPanelBtn = document.getElementById('memPanelBtn');
+const backBtn = document.getElementById('backBtn');
+const memModal = document.getElementById('memModal');
+const memClose = document.getElementById('memClose');
+const memKey = document.getElementById('memKey');
+const memValue = document.getElementById('memValue');
+const memScope = document.getElementById('memScope');
+const memAdd = document.getElementById('memAdd');
+const memRefresh = document.getElementById('memRefresh');
+const memList = document.getElementById('memList');
+
+function loadTheme(){
+  const t = localStorage.getItem('theme') || 'theme-dark';
+  themeSel.value = t;
+  document.body.className = t;
+}
+themeSel.onchange = ()=>{
+  localStorage.setItem('theme', themeSel.value);
+  document.body.className = themeSel.value;
+};
+
+async function loadModels(){
+  try{
+    const r = await fetch('/api/models');
+    const data = await r.json();
+    modelSel.innerHTML='';
+    for(const m of data.models || []){
+      const opt=document.createElement('option');
+      opt.value=m; opt.textContent=m;
+      modelSel.appendChild(opt);
+    }
+    const saved = localStorage.getItem('model');
+    if(saved) modelSel.value = saved;
+  }catch(e){}
+}
+modelSel.onchange = ()=> localStorage.setItem('model', modelSel.value);
+
+async function loadVoices(){
+  try{
+    const r = await fetch('/api/voices');
+    const data = await r.json();
+    voiceSel.innerHTML='';
+    for(const v of data.voices || []){
+      const opt=document.createElement('option');
+      opt.value=v; opt.textContent=v;
+      voiceSel.appendChild(opt);
+    }
+    const saved = localStorage.getItem('voice');
+    if(saved) voiceSel.value = saved;
+    else if(data.default) voiceSel.value = data.default;
+  }catch(e){}
+}
+voiceSel.onchange = ()=> localStorage.setItem('voice', voiceSel.value);
+
+webChk.checked = localStorage.getItem('web') === '1';
+webChk.onchange = ()=> localStorage.setItem('web', webChk.checked ? '1' : '0');
+
+memChk.checked = localStorage.getItem('use_mem') !== '0';
+memChk.onchange = async ()=>{
+  localStorage.setItem('use_mem', memChk.checked ? '1' : '0');
+  const tid = localStorage.getItem('threadId');
+  if(tid){
+    await fetch('/api/thread/use_memory', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({thread_id: tid, use_memory: memChk.checked})
+    });
+  }
+};
+
+function toggleMem(open){
+  memModal.hidden = !open;
+  if(open) loadMemList();
+}
+memPanelBtn.onclick = ()=>{ toggleMem(true); };
+memClose.onclick = ()=> toggleMem(false);
+memRefresh.onclick = ()=> loadMemList();
+memAdd.onclick = async ()=>{
+  const value = memValue.value.trim(); if(!value) return;
+  const key = memKey.value.trim() || null;
+  const scope = memScope.value || 'other';
+  await fetch('/api/memory/add', {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({key, value, scope})
+  });
+  memValue.value='';
+  loadMemList();
+};
+async function loadMemList(){
+  const active = await (await fetch('/api/memory/list?active=1')).json();
+  const inactive = await (await fetch('/api/memory/list?active=0')).json();
+  memList.innerHTML = '';
+  const section = (title, items, isActive)=>{
+    const h = document.createElement('h4');
+    h.textContent = title; memList.appendChild(h);
+    if(items.length===0){
+      const p=document.createElement('div'); p.className='memitem'; p.textContent='(pusto)';
+      memList.appendChild(p); return;
+    }
+    for(const m of items){
+      const it=document.createElement('div'); it.className='memitem';
+      it.innerHTML=`<div><b>${m.key||'(brak klucza)'}</b> — <i>${m.scope}</i></div><div>${m.value}</div><div class="muted">#${m.id} • ${m.created_at}</div>`;
+      const act=document.createElement('div'); act.className='actions';
+      const btn=document.createElement('button'); btn.textContent=isActive?'Zapomnij':'Przywróć';
+      btn.onclick=async()=>{
+        await fetch(isActive?'/api/memory/forget':'/api/memory/restore',{
+          method:'POST', headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({id:m.id})
+        });
+        loadMemList();
+      };
+      act.appendChild(btn); it.appendChild(act); memList.appendChild(it);
+    }
+  };
+  section('Aktywne', active, true);
+  section('Wyłączone', inactive, false);
+}
+
+backBtn.onclick = ()=>{ window.location = '/'; };
+
+function init(){
+  loadTheme();
+  loadModels();
+  loadVoices();
+}
+window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- Serve the `public` directory at `/` so `style.css` and `script.js` load via relative paths
- Keep file and memory dialogs hidden until opened and route settings to its own page

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo compiled`


------
https://chatgpt.com/codex/tasks/task_e_68b45accd408832d91237c4d33d8c007