### PR TITLE
Hide modals when hidden attribute present

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -57,6 +57,7 @@ img.chatimg{max-width:60%;border-radius:12px;border:1px solid var(--border);disp
 /* Modale */
 .hidden{display:none}
 .modal{position:fixed;left:0;top:0;right:0;bottom:0;background:rgba(0,0,0,.4);display:flex;align-items:center;justify-content:center;z-index:10}
+.modal[hidden]{display:none}
 .modalcard{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:16px;max-width:90vw;max-height:90vh;overflow:auto;min-width:300px}
 .modalhead{display:flex;justify-content:space-between;align-items:center;gap:8px;margin-bottom:8px}
 .modalhead .row{display:flex;gap:8px}


### PR DESCRIPTION
## Summary
- Ensure modals with `hidden` attribute are not displayed

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`
- `node - <<'NODE'
const fs = require('fs');
const code = fs.readFileSync('public/script.js','utf8');
const match = code.match(/function showFilesModal[\s\S]*?fileInp.onchange/);
const snippet = match ? match[0] : '';
const vm = require('vm');
const sandbox = {filesModal:{hidden:true},filesBtn:{},filesClose:{},filesUpload:{},fileInp:{},loadFilesList:()=>{console.log('loadFilesList called');}};
vm.createContext(sandbox);
vm.runInContext(snippet, sandbox);
sandbox.filesBtn.onclick();
console.log('after open hidden?', sandbox.filesModal.hidden);
sandbox.filesClose.onclick();
console.log('after close hidden?', sandbox.filesModal.hidden);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b462c4d1bc832dbc001499b67de5d5