### PR TITLE
feat: handle attachments and unify data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ python app.py
 
 ## Dane użytkownika
 
-Domyślne dane (baza i załączniki) trafiają do katalogu `~/.config/cheapchat`:
+Domyślna lokalizacja danych (baza i załączniki) to podkatalog `data/` w repozytorium. Możesz ją zmienić, ustawiając zmienną środowiskową `CHEAPCHAT_DATA_DIR`.
 
 ```
-~/.config/cheapchat/
+data/
 ├── memory.sqlite
 └── static/
     ├── docs/


### PR DESCRIPTION
## Summary
- centralize user data under configurable CHEAPCHAT_DATA_DIR with default `data/`
- remove duplicate `/settings` route definition
- send document contents with messages and allow selecting attachments in UI

## Testing
- `python -m py_compile app.py`
- `node --check public/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b61894ad24832db9c7f8832ff259f3