### PR TITLE
Store uploaded and generated files in temp locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,11 @@ python app.py
 
 ## Dane użytkownika
 
-Domyślna lokalizacja danych (baza i załączniki) to podkatalog `data/` w repozytorium. Możesz ją zmienić, ustawiając zmienną środowiskową `CHEAPCHAT_DATA_DIR`.
+Domyślna lokalizacja danych (np. bazy) to katalog `~/.config/cheapchat`. Możesz ją zmienić, ustawiając zmienną środowiskową `CHEAPCHAT_DATA_DIR`.
+
+Przesłane i generowane pliki są przechowywane wyłącznie w systemowym katalogu tymczasowym i mogą zostać usunięte po zakończeniu sesji.
 
 ```
-data/
-├── memory.sqlite
-└── static/
-    ├── docs/
-    └── images/
+~/.config/cheapchat/
+└── memory.sqlite
 ```


### PR DESCRIPTION
## Summary
- Save uploaded documents and generated images in temporary files instead of persistent directories
- Add background cleanup for temporary files and introduce `/api/temp/{id}` endpoint to serve them
- Document default data path and temporary nature of user files

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b86784ec832d8ba8a667d5974fb8