### PR TITLE
Enable data link generation for PDF/ODT

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ python generate_data_links.py
 
 Pierwsza linia zawiera URL z plikiem PDF, druga – z dokumentem ODT. Linki można bezpośrednio umieszczać w odpowiedziach lub w tagach HTML, aby przeglądarka pobrała plik z pamięci podręcznej.
 
+Endpoint API `/api/data-links` zwraca podobne linki w formacie JSON:
+
+```
+curl http://localhost:8000/api/data-links
+```
+
+Odpowiedź zawiera pola `pdf`, `odt` oraz `html` z gotowymi łączami.
+
 ## Dane użytkownika
 
 Domyślne dane (baza i załączniki) trafiają do katalogu `~/.config/cheapchat`:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Na systemach z PEP-668 (np. Debian/Ubuntu) instaluj w wirtualnym środowisku lub
 python app.py
 ```
 
+## Generowanie linków `data:` do plików
+
+Skrypt `generate_data_links.py` tworzy w pamięci przykładowe pliki PDF i ODT oraz wypisuje gotowe do użycia adresy `data:`.
+
+```bash
+python generate_data_links.py
+```
+
+Pierwsza linia zawiera URL z plikiem PDF, druga – z dokumentem ODT. Linki można bezpośrednio umieszczać w odpowiedziach lub w tagach HTML, aby przeglądarka pobrała plik z pamięci podręcznej.
+
 ## Dane użytkownika
 
 Domyślne dane (baza i załączniki) trafiają do katalogu `~/.config/cheapchat`:

--- a/app.py
+++ b/app.py
@@ -130,11 +130,6 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 def settings_page():
     return FileResponse(PUBLIC_DIR / "settings.html")
 
-
-@app.get("/settings")
-def settings_page():
-    return FileResponse(PUBLIC_DIR / "settings.html")
-
 # -------------- DB + MIGRACJE ------------------
 def ensure_schema():
     with sqlite3.connect(DB_PATH) as conn:

--- a/app.py
+++ b/app.py
@@ -36,6 +36,7 @@ from odf.opendocument import load as odf_load
 from odf import text as odf_text
 from PIL import Image
 from reportlab.pdfgen import canvas
+from generate_data_links import pdf_data_url, odt_data_url
 
 # ----------------- KONFIG ----------------------
 API_KEY = None  # loaded dynamically
@@ -129,6 +130,14 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 @app.get("/settings")
 def settings_page():
     return FileResponse(PUBLIC_DIR / "settings.html")
+
+
+@app.get("/api/data-links")
+def data_links():
+    pdf = pdf_data_url("Hello PDF")
+    odt = odt_data_url("Hello ODT")
+    html = f'<a href="{pdf}">PDF</a><br><a href="{odt}">ODT</a>'
+    return {"pdf": pdf, "odt": odt, "html": html}
 
 # -------------- DB + MIGRACJE ------------------
 def ensure_schema():

--- a/generate_data_links.py
+++ b/generate_data_links.py
@@ -1,0 +1,40 @@
+import base64
+import io
+
+try:
+    from reportlab.pdfgen import canvas
+except ImportError:
+    print("Brak biblioteki 'reportlab'. Zainstaluj ją poleceniem 'pip install reportlab'.")
+    raise SystemExit(1)
+
+try:
+    from odf.opendocument import OpenDocumentText
+    from odf.text import P
+except ImportError:
+    print("Brak biblioteki 'odfpy'. Zainstaluj ją poleceniem 'pip install odfpy'.")
+    raise SystemExit(1)
+
+
+def pdf_data_url(text: str = "Hello world") -> str:
+    """Zwróć minimalny PDF jako URL typu data."""
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    c.drawString(72, 720, text)
+    c.showPage()
+    c.save()
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:application/pdf;base64,{b64}"
+
+
+def odt_data_url(text: str) -> str:
+    doc = OpenDocumentText()
+    doc.text.addElement(P(text=text))
+    buf = io.BytesIO()
+    doc.save(buf)
+    b64 = base64.b64encode(buf.getvalue()).decode()
+    return f"data:application/vnd.oasis.opendocument.text;base64,{b64}"
+
+
+if __name__ == "__main__":
+    print("PDF link:", pdf_data_url("Hello PDF"))
+    print("ODT link:", odt_data_url("Hello ODT"))

--- a/generate_data_links.py
+++ b/generate_data_links.py
@@ -36,5 +36,5 @@ def odt_data_url(text: str) -> str:
 
 
 if __name__ == "__main__":
-    print("PDF link:", pdf_data_url("Hello PDF"))
-    print("ODT link:", odt_data_url("Hello ODT"))
+    print(f'<a href="{pdf_data_url("Hello PDF")}">PDF</a>')
+    print(f'<a href="{odt_data_url("Hello ODT")}">ODT</a>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-docx
 odfpy
 pytesseract
 Pillow
+reportlab


### PR DESCRIPTION
## Summary
- Generate PDFs dynamically with ReportLab and produce data URLs
- Add friendly dependency checks for missing libraries
- Document and expose data link script, add ReportLab to requirements
- Remove duplicate /settings route handler

## Testing
- `python -m py_compile generate_data_links.py`
- `python -m py_compile app.py`
- `python generate_data_links.py | head -n 5` *(fails: Brak biblioteki 'reportlab')*
- `pip install reportlab odfpy` *(fails: Could not find a version that satisfies the requirement reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_68b6127988d4832d8a461cc8f8002c34